### PR TITLE
feat: added mounting handlers

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,23 +5,26 @@ import HomeScreen from './screens/HomeScreen';
 import BasicScreen from './screens/BasicScreen';
 import ModalScreen from './screens/ModalScreen';
 import PopoverScreen from './screens/PopoverScreen';
+import { PortalHost } from '@gorhom/portal';
 
 const Stack = createStackNavigator();
 
 const App = () => {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen
-          name="Home"
-          component={HomeScreen}
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen name="Basic" component={BasicScreen} />
-        <Stack.Screen name="Modal" component={ModalScreen} />
-        <Stack.Screen name="Popover" component={PopoverScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <PortalHost>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Home"
+            component={HomeScreen}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen name="Basic" component={BasicScreen} />
+          <Stack.Screen name="Modal" component={ModalScreen} />
+          <Stack.Screen name="Popover" component={PopoverScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </PortalHost>
   );
 };
 

--- a/example/src/screens/ModalScreen.tsx
+++ b/example/src/screens/ModalScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Portal, PortalHost } from '@gorhom/portal';
+import { Portal } from '@gorhom/portal';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import SimpleModal from '../components/SimpleModal';
 
@@ -46,10 +46,8 @@ const styles = StyleSheet.create({
 });
 
 export default () => (
-  <PortalHost>
-    <Tab.Navigator>
-      <Tab.Screen name="Home" component={BasicScreen} />
-      <Tab.Screen name="Settings" component={BasicScreen} />
-    </Tab.Navigator>
-  </PortalHost>
+  <Tab.Navigator>
+    <Tab.Screen name="Home" component={BasicScreen} />
+    <Tab.Screen name="Settings" component={BasicScreen} />
+  </Tab.Navigator>
 );

--- a/example/src/screens/PopoverScreen.tsx
+++ b/example/src/screens/PopoverScreen.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Portal, PortalHost } from '@gorhom/portal';
+import { Portal } from '@gorhom/portal';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import SimplePopover from '../components/SimplePopover';
 
@@ -32,7 +32,7 @@ const BasicScreen = () => {
 
   // callbacks
   const handleMountTopPopoverPress = useCallback(() => {
-    topButtonRef.current?.measure((x, y, width, height) => {
+    topButtonRef.current?.measureInWindow((x, y, width, height) => {
       setConfig({
         position: 'top',
         targetLayout: {
@@ -47,7 +47,7 @@ const BasicScreen = () => {
   }, []);
 
   const handleMountBottomPopoverPress = useCallback(() => {
-    bottomButtonRef.current?.measure((x, y, width, height) => {
+    bottomButtonRef.current?.measureInWindow((x, y, width, height) => {
       setConfig({
         position: 'bottom',
         targetLayout: {
@@ -110,10 +110,8 @@ const styles = StyleSheet.create({
 });
 
 export default () => (
-  <PortalHost>
-    <Tab.Navigator sceneContainerStyle={{ height: WINDOW_HEIGHT }}>
-      <Tab.Screen name="Home" component={BasicScreen} />
-      <Tab.Screen name="Settings" component={BasicScreen} />
-    </Tab.Navigator>
-  </PortalHost>
+  <Tab.Navigator sceneContainerStyle={{ height: WINDOW_HEIGHT }}>
+    <Tab.Screen name="Home" component={BasicScreen} />
+    <Tab.Screen name="Settings" component={BasicScreen} />
+  </Tab.Navigator>
 );

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -3,7 +3,12 @@ import { nanoid } from 'nanoid/non-secure';
 import { usePortal } from '../../hooks';
 import type { PortalProps } from './types';
 
-const PortalComponent = ({ name: _providedName, children }: PortalProps) => {
+const PortalComponent = ({
+  name: _providedName,
+  handleOnMount,
+  handleOnUnmount,
+  children,
+}: PortalProps) => {
   //#region hooks
   const { mount, unmount, update } = usePortal();
   //#endregion
@@ -14,9 +19,20 @@ const PortalComponent = ({ name: _providedName, children }: PortalProps) => {
 
   //#region effects
   useEffect(() => {
-    mount(name, children);
+    if (handleOnMount) {
+      handleOnMount(() => mount(name, children));
+    } else {
+      mount(name, children);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useEffect(() => {
     return () => {
-      unmount(name);
+      if (handleOnUnmount) {
+        handleOnUnmount(() => unmount(name));
+      } else {
+        unmount(name);
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/portal/types.d.ts
+++ b/src/components/portal/types.d.ts
@@ -8,6 +8,20 @@ export interface PortalProps {
    */
   name?: string;
   /**
+   * Override internal mounting functionality, this is useful
+   * if you want to trigger any action before mounting the portal content.
+   * @type (mount?: () => void) => void
+   * @default undefined
+   */
+  handleOnMount?: (mount?: () => void) => void;
+  /**
+   * Override internal un-mounting functionality, this is useful
+   * if you want to trigger any action before un-mounting the portal content.
+   * @type (mount?: () => void) => void
+   * @default undefined
+   */
+  handleOnUnmount?: (unmount?: () => void) => void;
+  /**
    * Portal content.
    */
   children?: ReactNode | ReactNode[];

--- a/src/contexts/portal.ts
+++ b/src/contexts/portal.ts
@@ -1,8 +1,4 @@
 import { createContext } from 'react';
 import type { PortalMethods } from '../types';
 
-export const PortalContext = createContext<PortalMethods>({
-  mount: () => {},
-  update: () => {},
-  unmount: () => {},
-});
+export const PortalContext = createContext<PortalMethods | null>(null);

--- a/src/hooks/usePortal.ts
+++ b/src/hooks/usePortal.ts
@@ -1,4 +1,14 @@
 import { useContext } from 'react';
 import { PortalContext } from '../contexts';
 
-export const usePortal = () => useContext(PortalContext);
+export const usePortal = () => {
+  const value = useContext(PortalContext);
+
+  if (value === null) {
+    throw new Error(
+      "Portal context cannot be null, please add 'PortalHost' to the root component."
+    );
+  }
+
+  return value;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default as Portal } from './components/portal';
 export { default as PortalHost } from './components/portalHost';
+export { usePortal } from './hooks/usePortal';


### PR DESCRIPTION
#Motivation

for more advance usage, i allow overriding mounting functionalities to execute any action then call the portal mounting ones.

this gives `BottomSheet` more control to mount and unmount the modal while navigating between screens.

https://github.com/gorhom/react-native-bottom-sheet/issues/240