### PR TITLE
chore: upgrade nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bootstrap": "yarn example && yarn && pod install"
   },
   "dependencies": {
-    "nanoid": "^3.1.23"
+    "nanoid": "^3.3.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,10 +7183,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.23:
-  version "3.1.23"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
-  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+nanoid@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
Fixes security vulnerability in nanoid: [CVE-2021-23566](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2)

I ran the linting and typescript checks and this did not add any more warnings/errors that didn't already exist.
I was unable to run the example project, maybe because I don't use Expo 🤷 .