### PR TITLE
fix: avoid non-defined global error on web

### DIFF
--- a/src/utilities/logger.ts
+++ b/src/utilities/logger.ts
@@ -8,8 +8,11 @@ type Print = (options: PrintOptions) => void;
 
 let isLoggingEnabled = false;
 
+// __DEV__ global is by default not defined in React Native Web builds
+const isDev = Boolean(typeof __DEV__ !== 'undefined' && __DEV__)
+
 const enableLogging = () => {
-  if (!__DEV__) {
+  if (!isDev) {
     console.warn('[Portal] could not enable logging on production!');
     return;
   }
@@ -18,7 +21,7 @@ const enableLogging = () => {
 
 let print: Print = () => {};
 
-if (__DEV__) {
+if (isDev) {
   print = ({ component, method, params }) => {
     if (!isLoggingEnabled) {
       return;


### PR DESCRIPTION
Closes https://github.com/gorhom/react-native-portal/issues/29

Uses an approach seen in many React Native + React Native Web projects to work out-of-the-box on web without requiring extra webpack config.