### PR TITLE
chore: update `nanoid` to 5.0.9 to resolve warnings of CVE-2024-55565

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bootstrap": "yarn example && yarn && pod install"
   },
   "dependencies": {
-    "nanoid": "^3.3.1"
+    "nanoid": "^5.0.9"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,10 +7183,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+nanoid@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.9.tgz#977dcbaac055430ce7b1e19cf0130cea91a20e50"
+  integrity sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
CVE: https://www.cve.org/CVERecord?id=CVE-2024-55565

PR simply updates `nanoid` to 5.0.9

Based on this compared, the changes (and change log) don't indicate to my any concerns for upgrading two major versions
https://github.com/ai/nanoid/compare/3.3.1...5.0.9

Notes from `nanoid` 4.0 if curious
> ## 4.0
> * Removed CommonJS support. Nano ID 4 will work only with ESM applications.
>   We will support 3.x branch with CommonJS for users who can’t migrate to ESM.
> * Removed Node.js 10 and Node.js 12 support.
> * Reduced npm package size.